### PR TITLE
Add CI badge to README File

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Ona SRE Tooling
+## Ona SRE Tooling [![Build Status](https://github.com/onaio/sre-tooling/workflows/CI/badge.svg)](https://github.com/onaio/sre-tooling/actions?query=workflow%3ACI)
 
 A set of useful SRE tools. This project is written Golang (v1.12 and above recommended).
 


### PR DESCRIPTION
Add the GitHub Actions CI badge to the main README file.

Signed-off-by: Jason Rogena <jason@rogena.me>