### PR TITLE
Return Value of New Infrastructure Index if Updated

### DIFF
--- a/infra/index/update/update.go
+++ b/infra/index/update/update.go
@@ -133,5 +133,5 @@ func (update *Update) Process() {
 		cli.ExitCommandExecutionError()
 	}
 
-	notification.SendMessage(fmt.Sprintf("Tags for the %s resource with ID '%s' successfully updated to match its new index '%s'", provider, *update.idFlag, newIndexStr))
+	notification.SendMessage(newIndexStr)
 }


### PR DESCRIPTION
If the infra index update sub-command is able to update an instance's
index, return just the new index (so as to allow other commands to use
the value).

Signed-off-by: Jason Rogena <jason@rogena.me>