### PR TITLE
Adds Infra Expiry Query Sub-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Ona SRE Tooling [![Build Status](https://github.com/onaio/sre-tooling/workflows/CI/badge.svg)](https://github.com/onaio/sre-tooling/actions?query=workflow%3ACI)
 
-A set of useful SRE tools. This project is written Golang (v1.12 and above recommended).
+A set of useful SRE tools. This project is written Golang (v1.13 and above).
 
 ![Linux Gopher](./assets/gopher.png)
 

--- a/infra/expiry/expiry.go
+++ b/infra/expiry/expiry.go
@@ -1,0 +1,56 @@
+package expiry
+
+import (
+	"flag"
+
+	"github.com/onaio/sre-tooling/infra/expiry/query"
+	"github.com/onaio/sre-tooling/libs/cli"
+)
+
+const name string = "expiry"
+
+// Expiry deals with commands related to infrastructure expiry
+type Expiry struct {
+	helpFlag    *bool
+	flagSet     *flag.FlagSet
+	subCommands []cli.Command
+}
+
+// Init initializes the command object
+func (expiry *Expiry) Init(helpFlagName string, helpFlagDescription string) {
+	expiry.flagSet = flag.NewFlagSet(expiry.GetName(), flag.ExitOnError)
+	expiry.helpFlag = expiry.flagSet.Bool(helpFlagName, false, helpFlagDescription)
+	query := new(query.Query)
+	query.Init(helpFlagName, helpFlagDescription)
+
+	expiry.subCommands = []cli.Command{query}
+}
+
+// GetName returns the value of the name constant
+func (expiry *Expiry) GetName() string {
+	return name
+}
+
+// GetDescription returns the description for the expiry command
+func (expiry *Expiry) GetDescription() string {
+	return "Related to infrastructure expiry"
+}
+
+// GetFlagSet returns a pointer to the flag.FlagSet associated to the command
+func (expiry *Expiry) GetFlagSet() *flag.FlagSet {
+	return expiry.flagSet
+}
+
+// GetSubCommands returns a slice of subcommands under the expiry command
+// (expect empty slice if none)
+func (expiry *Expiry) GetSubCommands() []cli.Command {
+	return expiry.subCommands
+}
+
+// GetHelpFlag returns a pointer to the initialized help flag for the command
+func (expiry *Expiry) GetHelpFlag() *bool {
+	return expiry.helpFlag
+}
+
+// Process does nothing, since this command has subcommands that actually do the processing
+func (expiry *Expiry) Process() {}

--- a/infra/expiry/expiry.go
+++ b/infra/expiry/expiry.go
@@ -3,6 +3,7 @@ package expiry
 import (
 	"flag"
 
+	"github.com/onaio/sre-tooling/infra/expiry/prune"
 	"github.com/onaio/sre-tooling/infra/expiry/query"
 	"github.com/onaio/sre-tooling/libs/cli"
 )
@@ -22,8 +23,10 @@ func (expiry *Expiry) Init(helpFlagName string, helpFlagDescription string) {
 	expiry.helpFlag = expiry.flagSet.Bool(helpFlagName, false, helpFlagDescription)
 	query := new(query.Query)
 	query.Init(helpFlagName, helpFlagDescription)
+	prune := new(prune.Prune)
+	prune.Init(helpFlagName, helpFlagDescription)
 
-	expiry.subCommands = []cli.Command{query}
+	expiry.subCommands = []cli.Command{query, prune}
 }
 
 // GetName returns the value of the name constant

--- a/infra/expiry/prune/prune.go
+++ b/infra/expiry/prune/prune.go
@@ -1,8 +1,124 @@
 package prune
 
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/onaio/sre-tooling/infra/expiry/query"
+	"github.com/onaio/sre-tooling/libs/cli"
+	"github.com/onaio/sre-tooling/libs/cli/flags"
+	"github.com/onaio/sre-tooling/libs/cloud"
+	"github.com/onaio/sre-tooling/libs/notification"
+)
+
 // Make sure there's a -safe flag (that's defaulted to true) where, e.g you are not allowed to terminate VMs that aren't already shut down
 // Make sure there's an -action flag (with possible values being 'terminate' & 'shutdown' and default value is 'shutdown') for controlling what action
 //  should be taken on expired resources
 // Make sure at least one filter flag (region, resource, tag) is provided to avoid catastrophic situations where all resources in an entire
 // cloud account are shut-down
 // Make sure there's a -yes flag (defaulted to false) that if not set to true will require a confirmation before resources are pruned
+
+const name string = "prune"
+const actionStop string = "stop"
+const actionTerminate string = "terminate"
+
+// Prune queries then notifies (using configured notification channels) infrastructure that has expired
+type Prune struct {
+	helpFlag             *bool
+	flagSet              *flag.FlagSet
+	providerFlag         *flags.StringArray
+	regionFlag           *flags.StringArray
+	typeFlag             *flags.StringArray
+	tagFlag              *flags.StringArray
+	maxAgeFlag           *string
+	expiryTagFlag        *string
+	expiryTagNAValueFlag *string
+	expiryTagFormatFlag  *string
+	safeFlag             *bool
+	actionFlag           *string
+	yesFlag              *bool
+	subCommands          []cli.Command
+}
+
+// Init initializes the command object
+func (prune *Prune) Init(helpFlagName string, helpFlagDescription string) {
+	prune.flagSet = flag.NewFlagSet(prune.GetName(), flag.ExitOnError)
+	prune.helpFlag = prune.flagSet.Bool(helpFlagName, false, helpFlagDescription)
+	prune.safeFlag = prune.flagSet.Bool("unsafe", false, "If set to true, command will not error if you try to terminate a resource that is stoppable but not stopped")
+	prune.actionFlag = prune.flagSet.String("action", actionStop, fmt.Sprintf("What action to take on a resource that has expired. Possible values are '%s' and '%s'", actionStop, actionTerminate))
+	prune.yesFlag = prune.flagSet.Bool("yes", false, "Whether to skip requiring a confirmation before pruning a resource")
+
+	prune.providerFlag,
+		prune.regionFlag,
+		prune.typeFlag,
+		prune.tagFlag,
+		prune.maxAgeFlag,
+		prune.expiryTagFlag,
+		prune.expiryTagNAValueFlag,
+		prune.expiryTagFormatFlag = query.AddQueryFlags(prune.flagSet)
+}
+
+// GetName returns the value of the name constant
+func (prune *Prune) GetName() string {
+	return name
+}
+
+// GetDescription returns the description for the prune command
+func (prune *Prune) GetDescription() string {
+	return "Prunes (stops or destroys) infrastructure that has expired"
+}
+
+// GetFlagSet returns a pointer to the flag.FlagSet associated to the command
+func (prune *Prune) GetFlagSet() *flag.FlagSet {
+	return prune.flagSet
+}
+
+// GetSubCommands returns a slice of subcommands under the prune command
+// (expect empty slice if none)
+func (prune *Prune) GetSubCommands() []cli.Command {
+	return prune.subCommands
+}
+
+// GetHelpFlag returns a pointer to the initialized help flag for the command
+func (prune *Prune) GetHelpFlag() *bool {
+	return prune.helpFlag
+}
+
+// Process fetches the list of infrastructure that matches the criteria provided by the user
+// and that has expired and sends notifications to the configured notification channels
+func (prune *Prune) Process() {
+	hasResourceErr := false
+	resourceErr := query.GetExpiredResources(
+		prune.providerFlag,
+		prune.regionFlag,
+		prune.typeFlag,
+		prune.tagFlag,
+		prune.maxAgeFlag,
+		prune.expiryTagFlag,
+		prune.expiryTagNAValueFlag,
+		prune.expiryTagFormatFlag,
+		func(resource *cloud.Resource, hasExpired bool, expiryTime time.Time, err error) {
+			if err != nil {
+				notification.SendMessage(fmt.Errorf("Could not figure out which resources have expired: %w", err).Error())
+				hasResourceErr = true
+				return
+			}
+
+			if !hasExpired {
+				return
+			}
+
+			// prune the resource
+		},
+	)
+
+	if resourceErr != nil {
+		notification.SendMessage(resourceErr.Error())
+		hasResourceErr = true
+	}
+
+	if hasResourceErr {
+		cli.ExitCommandExecutionError()
+	}
+}

--- a/infra/expiry/prune/prune.go
+++ b/infra/expiry/prune/prune.go
@@ -1,0 +1,8 @@
+package prune
+
+// Make sure there's a -safe flag (that's defaulted to true) where, e.g you are not allowed to terminate VMs that aren't already shut down
+// Make sure there's an -action flag (with possible values being 'terminate' & 'shutdown' and default value is 'shutdown') for controlling what action
+//  should be taken on expired resources
+// Make sure at least one filter flag (region, resource, tag) is provided to avoid catastrophic situations where all resources in an entire
+// cloud account are shut-down
+// Make sure there's a -yes flag (defaulted to false) that if not set to true will require a confirmation before resources are pruned

--- a/infra/expiry/query/query.go
+++ b/infra/expiry/query/query.go
@@ -106,16 +106,6 @@ func (query *Query) GetHelpFlag() *bool {
 // Process fetches the list of infrastructure that matches the criteria provided by the user
 // and that has expired and sends notifications to the configured notification channels
 func (query *Query) Process() {
-	if len(*query.expiryTagFlag) == 0 && len(*query.maxAgeFlag) == 0 {
-		notification.SendMessage("Either maximum age or expiry tag need to be provided")
-		cli.ExitCommandInterpretationError()
-	}
-
-	if len(*query.expiryTagFlag) > 0 && len(*query.expiryTagFormatFlag) == 0 {
-		notification.SendMessage("If the expiry tag is provided, then the expiry tag format also needs to be provided")
-		cli.ExitCommandInterpretationError()
-	}
-
 	hasResourceErr := false
 	expiryMessage := ""
 	resourceErr := GetExpiredResources(
@@ -167,6 +157,14 @@ func GetExpiredResources(
 	expiryTagNAValueFlag *string,
 	expiryTagFormatFlag *string,
 	expiredResourceHandler ExpiredResourceHandler) error {
+
+	if len(*expiryTagFlag) == 0 && len(*maxAgeFlag) == 0 {
+		return fmt.Errorf("Either maximum age or expiry tag need to be provided")
+	}
+
+	if len(*expiryTagFlag) > 0 && len(*expiryTagFormatFlag) == 0 {
+		return fmt.Errorf("If the expiry tag is provided, then the expiry tag format also needs to be provided")
+	}
 
 	allResources, resourcesErr := cloud.GetAllCloudResources(
 		cloud.GetFiltersFromCommandFlags(

--- a/infra/expiry/query/query.go
+++ b/infra/expiry/query/query.go
@@ -1,0 +1,260 @@
+package query
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onaio/sre-tooling/libs/notification"
+
+	"github.com/onaio/sre-tooling/libs/cli"
+	"github.com/onaio/sre-tooling/libs/cli/flags"
+	"github.com/onaio/sre-tooling/libs/cloud"
+)
+
+const name string = "query"
+const defaultTimeFormat string = "2006-01-02"
+const defaultExpiryTagNAValue string = "-"
+
+type ExpiredResourceHandler func(resource *cloud.Resource, hasExpired bool, expiryTime time.Time, err error)
+
+// Query queries then notifies (using configured notification channels) infrastructure that has expired
+type Query struct {
+	helpFlag             *bool
+	flagSet              *flag.FlagSet
+	providerFlag         *flags.StringArray
+	regionFlag           *flags.StringArray
+	typeFlag             *flags.StringArray
+	tagFlag              *flags.StringArray
+	maxAgeFlag           *string
+	expiryTagFlag        *string
+	expiryTagNAValueFlag *string
+	expiryTagFormatFlag  *string
+	subCommands          []cli.Command
+}
+
+// Init initializes the command object
+func (query *Query) Init(helpFlagName string, helpFlagDescription string) {
+	query.flagSet = flag.NewFlagSet(query.GetName(), flag.ExitOnError)
+	query.helpFlag = query.flagSet.Bool(helpFlagName, false, helpFlagDescription)
+
+	query.providerFlag,
+		query.regionFlag,
+		query.typeFlag,
+		query.tagFlag,
+		query.maxAgeFlag,
+		query.expiryTagFlag,
+		query.expiryTagNAValueFlag,
+		query.expiryTagFormatFlag = AddQueryFlags(query.flagSet)
+
+}
+
+// AddQueryFlags returns the flags required to query expired infrastructure in the order:
+// 	- Infrastructure filter tags, in the order needed by cloud.AddFilterFlags
+//  - Maximum age flag
+//	- Expiry tag flag
+//	- Expiry tag not applicable value
+//	- Expiry tag format flag
+func AddQueryFlags(flagSet *flag.FlagSet) (*flags.StringArray, *flags.StringArray, *flags.StringArray, *flags.StringArray, *string, *string, *string, *string) {
+	providerFlag,
+		regionFlag,
+		typeFlag,
+		tagFlag := cloud.AddFilterFlags(flagSet)
+
+	maxAgeFlag := flagSet.String("max-age", "", "Maximum age of a resource e.g '1h' to mean one hour. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', and 'h'.")
+	expiryTagFlag := flagSet.String("expiry-tag", "", "Name of the tag storing the time when the resource will expire")
+	expiryTagNAValue := flagSet.String("expiry-tag-na-value", defaultExpiryTagNAValue, "Value for the expiry tag that symbolizes that resource doesn't expire")
+	expiryTagFormatFlag := flagSet.String("expiry-tag-format", defaultTimeFormat, "The format of the time in the tag specified in -expiry-tag. Check the Golang time documentation on example formats here -> https://golang.org/pkg/time/#pkg-constants.")
+
+	return providerFlag,
+		regionFlag,
+		typeFlag,
+		tagFlag,
+		maxAgeFlag,
+		expiryTagFlag,
+		expiryTagNAValue,
+		expiryTagFormatFlag
+}
+
+// GetName returns the value of the name constant
+func (query *Query) GetName() string {
+	return name
+}
+
+// GetDescription returns the description for the query command
+func (query *Query) GetDescription() string {
+	return "Notifies, using configured notification channels, infrastructure that has expired"
+}
+
+// GetFlagSet returns a pointer to the flag.FlagSet associated to the command
+func (query *Query) GetFlagSet() *flag.FlagSet {
+	return query.flagSet
+}
+
+// GetSubCommands returns a slice of subcommands under the query command
+// (expect empty slice if none)
+func (query *Query) GetSubCommands() []cli.Command {
+	return query.subCommands
+}
+
+// GetHelpFlag returns a pointer to the initialized help flag for the command
+func (query *Query) GetHelpFlag() *bool {
+	return query.helpFlag
+}
+
+// Process fetches the list of infrastructure that matches the criteria provided by the user
+// and that has expired and sends notifications to the configured notification channels
+func (query *Query) Process() {
+	if len(*query.expiryTagFlag) == 0 && len(*query.maxAgeFlag) == 0 {
+		notification.SendMessage("Either maximum age or expiry tag need to be provided")
+		cli.ExitCommandInterpretationError()
+	}
+
+	if len(*query.expiryTagFlag) > 0 && len(*query.expiryTagFormatFlag) == 0 {
+		notification.SendMessage("If the expiry tag is provided, then the expiry tag format also needs to be provided")
+		cli.ExitCommandInterpretationError()
+	}
+
+	hasResourceErr := false
+	expiryMessage := ""
+	resourceErr := GetExpiredResources(
+		query.providerFlag,
+		query.regionFlag,
+		query.typeFlag,
+		query.tagFlag,
+		query.maxAgeFlag,
+		query.expiryTagFlag,
+		query.expiryTagNAValueFlag,
+		query.expiryTagFormatFlag,
+		func(resource *cloud.Resource, hasExpired bool, expiryTime time.Time, err error) {
+			if err != nil {
+				notification.SendMessage(fmt.Errorf("Could not figure out which resources have expired: %w", err).Error())
+				hasResourceErr = true
+				return
+			}
+
+			if !hasExpired {
+				return
+			}
+
+			expiryMessage = expiryMessage + fmt.Sprintf("%s - %s - %s - %s expired on %s\n", resource.Provider, resource.ResourceType, resource.Location, resource.ID, expiryTime.Format(time.RFC1123))
+		},
+	)
+
+	if resourceErr != nil {
+		notification.SendMessage(resourceErr.Error())
+		hasResourceErr = true
+	}
+
+	if len(expiryMessage) > 0 {
+		notification.SendMessage(expiryMessage)
+	}
+
+	if hasResourceErr {
+		cli.ExitCommandExecutionError()
+	}
+}
+
+// GetExpiredResources returns a list of expired resources
+func GetExpiredResources(
+	providerFlag *flags.StringArray,
+	regionFlag *flags.StringArray,
+	typeFlag *flags.StringArray,
+	tagFlag *flags.StringArray,
+	maxAgeFlag *string,
+	expiryTagFlag *string,
+	expiryTagNAValueFlag *string,
+	expiryTagFormatFlag *string,
+	expiredResourceHandler ExpiredResourceHandler) error {
+
+	allResources, resourcesErr := cloud.GetAllCloudResources(
+		cloud.GetFiltersFromCommandFlags(
+			providerFlag,
+			regionFlag,
+			typeFlag,
+			tagFlag),
+		true)
+
+	if resourcesErr != nil {
+		return fmt.Errorf("Could not get the list of cloud resources: %w", resourcesErr)
+	}
+
+	for _, curResource := range allResources {
+		hasExpired, expiryTime, hasExpiredErr := hasResourceExpired(curResource, maxAgeFlag, expiryTagFlag, expiryTagNAValueFlag, expiryTagFormatFlag)
+		expiredResourceHandler(curResource, hasExpired, expiryTime, hasExpiredErr)
+	}
+
+	return nil
+}
+
+// hasResourceExpired checks whether a resource has expired using the provided maximum age and expiry time flag
+func hasResourceExpired(resource *cloud.Resource, maxAge *string, expiryTag *string, expiryTagNAValue, expiryTagFormat *string) (bool, time.Time, error) {
+	maxAgeReached, maxAgeExpiryTime, maxAgeReachedErr := hasMaxAgeReached(resource, maxAge)
+	if maxAgeReached {
+		return true, maxAgeExpiryTime, maxAgeReachedErr
+	}
+
+	expiryTimeMature, matureExpiryTime, expiryTimeMatureErr := hasExpiryTimeMatured(resource, expiryTag, expiryTagNAValue, expiryTagFormat)
+	if expiryTimeMature {
+		return true, matureExpiryTime, expiryTimeMatureErr
+	}
+
+	// Only return the errors if all methods of evaluating expiry have failed
+	if maxAgeReachedErr != nil {
+		return false, maxAgeExpiryTime, maxAgeReachedErr
+	} else if expiryTimeMatureErr != nil {
+		return false, matureExpiryTime, expiryTimeMatureErr
+	}
+
+	return false, time.Now(), nil
+}
+
+// hasExpiryTimeMatured checks whether the expiry time in the provided resource tag has matured. Returns true if time
+// in the past (has matured)
+func hasExpiryTimeMatured(resource *cloud.Resource, expiryTag *string, expiryTagNAValue, expiryTagFormat *string) (bool, time.Time, error) {
+	expiryDateDiff := int64(0)
+	expiryTime := time.Now()
+
+	if len(*expiryTag) > 0 {
+		expiryTimeString, expiryTagDefined := resource.Tags[*expiryTag]
+		expiryTimeString = strings.TrimSpace(expiryTimeString)
+
+		if expiryTagDefined && expiryTimeString != *expiryTagNAValue {
+			gotExpiryTime, expiryTimeErr := time.Parse(*expiryTagFormat, expiryTimeString)
+			expiryTime = gotExpiryTime
+
+			if expiryTimeErr != nil {
+				return false, expiryTime, fmt.Errorf("Could not parse the expiry time '%s' of resource '%s': %w", expiryTimeString, resource.ID, expiryTimeErr)
+			}
+
+			// substract now from the expiry time
+			expiryDateDiff = expiryTime.UnixNano() - time.Now().UnixNano()
+		}
+	}
+
+	return expiryDateDiff < 0, expiryTime, nil
+}
+
+// hasMaxAgeReached checks whether the provided resource has surpursed its maximum age.
+// Returns true if it has
+func hasMaxAgeReached(resource *cloud.Resource, maxAge *string) (bool, time.Time, error) {
+	maxAgeDiff := int64(0)
+	expiryTime := time.Now()
+
+	if len(*maxAge) > 0 {
+		maxAgeDuration, maxAgeDurationErr := time.ParseDuration(*maxAge)
+
+		if maxAgeDurationErr != nil {
+			return false, expiryTime, fmt.Errorf("Unable to process the value of maximum age string %s: %w", *maxAge, maxAgeDurationErr)
+		}
+
+		// add max age to start time of the resource
+		expiryTime = resource.LaunchTime.Add(maxAgeDuration)
+
+		// subtract now from (launchtime + max age)
+		maxAgeDiff = expiryTime.UnixNano() - time.Now().UnixNano()
+	}
+
+	return maxAgeDiff < 0, expiryTime, nil
+}

--- a/infra/expiry/query/query_test.go
+++ b/infra/expiry/query/query_test.go
@@ -1,0 +1,269 @@
+package query
+
+import (
+	"testing"
+	"time"
+
+	"github.com/onaio/sre-tooling/libs/cloud"
+)
+
+// Test whether maxAge returns the right values if the provided maximum age is a blank string
+func TestHasMaxAgeReachedEmptyMaxAge(t *testing.T) {
+	resource := cloud.Resource{
+		Provider:   "testProvider",
+		ID:         "blah-id",
+		Location:   "eu-central-1a",
+		LaunchTime: time.Now(),
+		Tags:       map[string]string{},
+		Properties: map[string]string{}}
+	maxAge := ""
+	maxAgeReached, _, maxAgeErr := hasMaxAgeReached(&resource, &maxAge)
+
+	if maxAgeReached {
+		t.Errorf("Resource should not be expired if provided maximum age is '%s'", maxAge)
+	}
+
+	if maxAgeErr != nil {
+		t.Errorf("Error should not be returned if provided maximum age is '%s'", maxAge)
+	}
+}
+
+// Test whether maxAge returns the right values if the provided maximum age is an unparseable string
+func TestHasMaxAgeReachedIncorrectMaxAge(t *testing.T) {
+	resource := cloud.Resource{
+		Provider:   "testProvider",
+		ID:         "blah-id",
+		Location:   "eu-central-1a",
+		LaunchTime: time.Now(),
+		Tags:       map[string]string{},
+		Properties: map[string]string{}}
+	maxAge := "dfds"
+	maxAgeReached, _, maxAgeErr := hasMaxAgeReached(&resource, &maxAge)
+
+	if maxAgeReached {
+		t.Errorf("Resource should not be expired if provided maximum age is '%s'", maxAge)
+	}
+
+	if maxAgeErr == nil {
+		t.Errorf("Error should be returned if provided maximum age is '%s'", maxAge)
+	}
+}
+
+// Test whether maxAge returns the right values if the provided maximum age hasn't yet been reached
+func TestHasMaxAgeReachedImmatureMaxAge(t *testing.T) {
+	resource := cloud.Resource{
+		Provider:   "testProvider",
+		ID:         "blah-id",
+		Location:   "eu-central-1a",
+		LaunchTime: time.Now(),
+		Tags:       map[string]string{},
+		Properties: map[string]string{}}
+	maxAge := "1h" // resource is expected to expire after 1 hour
+	maxAgeReached, _, maxAgeErr := hasMaxAgeReached(&resource, &maxAge)
+
+	if maxAgeReached {
+		t.Errorf("Resource should not be expired if provided maximum age is '%s'", maxAge)
+	}
+
+	if maxAgeErr != nil {
+		t.Errorf("Error should not be returned if provided maximum age is '%s'", maxAge)
+	}
+}
+
+// Test whether maxAge returns the right values if the provided maximum age has been reached
+func TestHasMaxAgeReachedMatureMaxAge(t *testing.T) {
+	launchTime := time.Now().Add(-time.Hour) // 1 hour in the past
+	resource := cloud.Resource{
+		Provider:   "testProvider",
+		ID:         "blah-id",
+		Location:   "eu-central-1a",
+		LaunchTime: launchTime,
+		Tags:       map[string]string{},
+		Properties: map[string]string{}}
+	maxAge := "40m" // resource is expected to expire after 30 min from now
+	maxAgeReached, expiryTime, maxAgeErr := hasMaxAgeReached(&resource, &maxAge)
+
+	if !maxAgeReached {
+		t.Errorf("Resource should be expired if provided maximum age is '%s'", maxAge)
+	}
+
+	if maxAgeErr != nil {
+		t.Errorf("Error should not be returned if provided maximum age is '%s'", maxAge)
+	}
+
+	// expecting expiry time to be around 20min in the past
+	timeDiff := time.Now().Unix() - expiryTime.Unix()
+	if timeDiff < (19*60) || timeDiff > (21*60) { // Give an error mergin of 2min
+		t.Errorf("Expecting expiry time to be around 20min in the past if maximum age is '%s' and launch time is '%s'. Time difference is '%d' seconds", maxAge, launchTime.Format(time.RFC1123), timeDiff)
+	}
+}
+
+// Test whether hasExpiryTimeMatured returns the right values if the provided tag is not set
+func TestHasExpiryTimeMaturedTagNotSet(t *testing.T) {
+	tagName := "someRandomTag"
+	expiryTagNAValue := defaultExpiryTagNAValue
+	timeFormat := defaultTimeFormat
+
+	resource := cloud.Resource{
+		Provider:   "testProvider",
+		ID:         "blah-id",
+		Location:   "eu-central-1a",
+		LaunchTime: time.Now(),
+		Tags:       map[string]string{},
+		Properties: map[string]string{}}
+
+	expiryMatured, _, expiryMaturedErr := hasExpiryTimeMatured(&resource, &tagName, &expiryTagNAValue, &timeFormat)
+
+	if expiryMatured {
+		t.Errorf("Resource should not be expired if provided expiry tag has not been set")
+	}
+
+	if expiryMaturedErr != nil {
+		t.Errorf("Error should not be returned if provided expiry tag has not been set")
+	}
+}
+
+// Test whether hasExpiryTimeMatured returns the right values if the provided tag's value is empty
+func TestHasExpiryTimeMaturedTagEmpty(t *testing.T) {
+	tagName := "someRandomTag"
+	expiryTagNAValue := defaultExpiryTagNAValue
+	timeFormat := defaultTimeFormat
+
+	resource := cloud.Resource{
+		Provider:   "testProvider",
+		ID:         "blah-id",
+		Location:   "eu-central-1a",
+		LaunchTime: time.Now(),
+		Tags: map[string]string{
+			tagName: "",
+		},
+		Properties: map[string]string{}}
+
+	expiryMatured, _, expiryMaturedErr := hasExpiryTimeMatured(&resource, &tagName, &expiryTagNAValue, &timeFormat)
+
+	if expiryMatured {
+		t.Errorf("Resource should not be expired if provided expiry tag is empty")
+	}
+
+	if expiryMaturedErr == nil {
+		t.Errorf("Error should be returned if provided expiry tag has is empty")
+	}
+}
+
+// Test whether hasExpiryTimeMatured returns the right values if the provided tag's value cannot be parsed
+func TestHasExpiryTimeMaturedIncorrectTagValue(t *testing.T) {
+	tagName := "someRandomTag"
+	tagValue := "sdfsdadds"
+	expiryTagNAValue := defaultExpiryTagNAValue
+	timeFormat := defaultTimeFormat
+
+	resource := cloud.Resource{
+		Provider:   "testProvider",
+		ID:         "blah-id",
+		Location:   "eu-central-1a",
+		LaunchTime: time.Now(),
+		Tags: map[string]string{
+			tagName: tagValue,
+		},
+		Properties: map[string]string{}}
+
+	expiryMatured, _, expiryMaturedErr := hasExpiryTimeMatured(&resource, &tagName, &expiryTagNAValue, &timeFormat)
+
+	if expiryMatured {
+		t.Errorf("Resource should not be expired if provided expiry tag is '%s'", tagValue)
+	}
+
+	if expiryMaturedErr == nil {
+		t.Errorf("Error should be returned if provided expiry tag has is '%s'", tagValue)
+	}
+}
+
+// Test whether hasExpiryTimeMatured returns the right values if the incorrect time format is provided
+func TestHasExpiryTimeMaturedIncorrectTimeFormat(t *testing.T) {
+	tagName := "someRandomTag"
+	tagValue := "2020-01-01"
+	expiryTagNAValue := defaultExpiryTagNAValue
+	timeFormat := "fdsafdsfewf"
+
+	resource := cloud.Resource{
+		Provider:   "testProvider",
+		ID:         "blah-id",
+		Location:   "eu-central-1a",
+		LaunchTime: time.Now(),
+		Tags: map[string]string{
+			tagName: tagValue,
+		},
+		Properties: map[string]string{}}
+
+	expiryMatured, _, expiryMaturedErr := hasExpiryTimeMatured(&resource, &tagName, &expiryTagNAValue, &timeFormat)
+
+	if expiryMatured {
+		t.Errorf("Resource should not be expired if expiry time format is '%s'", timeFormat)
+	}
+
+	if expiryMaturedErr == nil {
+		t.Errorf("Error should be returned if provided expiry time format is '%s'", timeFormat)
+	}
+}
+
+// Test whether hasExpiryTimeMatured returns the right values if the resource tag indicates an expired resource
+func TestHasExpiryTimeMaturedExpiredResource(t *testing.T) {
+	expiryTagNAValue := defaultExpiryTagNAValue
+	timeFormat := time.RFC1123
+	tagName := "someRandomTag"
+	tagValue := time.Now().Add(-(time.Hour * 24)).Format(timeFormat)
+
+	resource := cloud.Resource{
+		Provider:   "testProvider",
+		ID:         "blah-id",
+		Location:   "eu-central-1a",
+		LaunchTime: time.Now(),
+		Tags: map[string]string{
+			tagName: tagValue,
+		},
+		Properties: map[string]string{}}
+
+	expiryMatured, expiryTime, expiryMaturedErr := hasExpiryTimeMatured(&resource, &tagName, &expiryTagNAValue, &timeFormat)
+
+	if !expiryMatured {
+		t.Errorf("Resource should be expired if expiry time is '%s'", tagValue)
+	}
+
+	if expiryMaturedErr != nil {
+		t.Errorf("Error should not be returned")
+	}
+
+	// expecting expiry time to be around 20min in the past
+	timeDiff := time.Now().Unix() - expiryTime.Unix()
+	if timeDiff < (23*3600) || timeDiff > (25*3600) { // Give an error mergin of 2 hours
+		t.Errorf("Expecting expiry time to be around 24hrs in the past if expiry time is '%s'", tagValue)
+	}
+}
+
+// Test whether hasExpiryTimeMatured returns the right values if the resource tag indicates a resource that hasn't expired
+func TestHasExpiryTimeMaturedNotExpiredResource(t *testing.T) {
+	expiryTagNAValue := defaultExpiryTagNAValue
+	timeFormat := time.RFC1123
+	tagName := "someRandomTag"
+	tagValue := time.Now().Add((time.Hour)).Format(timeFormat)
+
+	resource := cloud.Resource{
+		Provider:   "testProvider",
+		ID:         "blah-id",
+		Location:   "eu-central-1a",
+		LaunchTime: time.Now(),
+		Tags: map[string]string{
+			tagName: tagValue,
+		},
+		Properties: map[string]string{}}
+
+	expiryMatured, _, expiryMaturedErr := hasExpiryTimeMatured(&resource, &tagName, &expiryTagNAValue, &timeFormat)
+
+	if expiryMatured {
+		t.Errorf("Resource should not be expired if expiry time is '%s'", tagValue)
+	}
+
+	if expiryMaturedErr != nil {
+		t.Errorf("Error should not be returned")
+	}
+}

--- a/infra/infra.go
+++ b/infra/infra.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	"github.com/onaio/sre-tooling/infra/bill"
+	"github.com/onaio/sre-tooling/infra/expiry"
 	"github.com/onaio/sre-tooling/infra/index"
 	"github.com/onaio/sre-tooling/infra/query"
 	"github.com/onaio/sre-tooling/libs/cli"
@@ -26,7 +27,9 @@ func (infra *Infra) Init(helpFlagName string, helpFlagDescription string) {
 	query.Init(helpFlagName, helpFlagDescription)
 	index := new(index.Index)
 	index.Init(helpFlagName, helpFlagDescription)
-	infra.subCommands = []cli.Command{bill, query, index}
+	expiry := new(expiry.Expiry)
+	expiry.Init(helpFlagName, helpFlagDescription)
+	infra.subCommands = []cli.Command{bill, query, index, expiry}
 }
 
 func (infra *Infra) GetName() string {

--- a/libs/cloud/aws.go
+++ b/libs/cloud/aws.go
@@ -203,3 +203,21 @@ func (a *AWS) updateEC2ResourceTag(region *string, resource *Resource, tagKey *s
 
 	return creatTagErr
 }
+
+func (a *AWS) updateResourceState(resource *Resource, safe bool, state string) error {
+	if resource.Provider != awsProviderName {
+		return fmt.Errorf("Resource's provider is %s instead of AWS. Cannot update the tag", resource.Provider)
+	}
+
+	switch resource.ResourceType {
+	case resourceTypeEc2:
+		return a.updateEC2ResourceState(resource, safe, state)
+	default:
+		return fmt.Errorf("Unknown resource type %s. Cannot update the tag", resource.ResourceType)
+	}
+}
+
+func (a *AWS) updateEC2ResourceState(resource *Resource, safe bool, state string) error {
+
+	return nil
+}

--- a/libs/cloud/cloud.go
+++ b/libs/cloud/cloud.go
@@ -14,6 +14,7 @@ type Provider interface {
 	getName() string
 	getAllResources(filter *Filter, quiet bool) ([]*Resource, error)
 	updateResourceTag(region *string, resource *Resource, tagKey *string, tagValue *string) error
+	updateResourceState(resource *Resource, safe bool, state string) error
 }
 
 type Resource struct {


### PR DESCRIPTION
Adds a sub-command to query expired resources based on either a tag
storing the expiry date or a time relative to now.

Fixes #2

Signed-off-by: Jason Rogena <jason@rogena.me>