### PR TITLE
Add a Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         go-version: 1.13.x
 
     - name: Run tests
-      run: go test -bench=. -v ./...
+      run: make test
 
   release:
     name: Release

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,10 @@ PREFIX := /usr/local
 GOFLAGS := -v -mod=mod
 EXTRA_GOFLAGS ?=
 
-build:
+test:
+	go test -bench=. -v ./...
+
+build: test
 	go build $(GOFLAGS) $(EXTRA_GOFLAGS)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+export GO111MODULE=on
+GOPROXY ?= https://gocenter.io,direct
+export GOPROXY
+
+BIN := sre-tooling
+DESTDIR :=
+PREFIX := /usr/local
+
+GOFLAGS := -v -mod=mod
+EXTRA_GOFLAGS ?=
+
+build:
+	go build $(GOFLAGS) $(EXTRA_GOFLAGS)
+
+clean:
+	go clean
+
+install: build
+	install -Dm755 ${BIN} ${DESTDIR}${PREFIX}/bin/${BIN}
+
+uninstall:
+	rm -f ${DESTDIR}${PREFIX}/bin/${BIN}


### PR DESCRIPTION
A Makefile makes it easier to build packaging. I have a PKGBUILD that I want to put up on AUR for ArchLinux, using make makes it far much simpler.