### PR TITLE
Throwing Errors When Resource Indexes are Unchanged

### DIFF
--- a/infra/index/calculate/calculate.go
+++ b/infra/index/calculate/calculate.go
@@ -215,7 +215,7 @@ func GetNewResourceIndex(
 	// Don't check if error emitted since that would have already been caught before
 	resourceIndex, _ := getResourceIndex(resource, indexTag)
 	if indexMap[resourceIndex] == 1 {
-		return resourceIndex, fmt.Errorf("Index for resource with ID %s doesn't need changing", resource.ID)
+		return resourceIndex, nil
 	}
 
 	// Try calculate a new index for the resource

--- a/infra/index/calculate/calculate_test.go
+++ b/infra/index/calculate/calculate_test.go
@@ -74,6 +74,7 @@ func TestGetNewResourceIndexDuplicateIndexGreaterZero(t *testing.T) {
 
 // Test if error thrown when provided resource ID is not found
 func TestGetNewResourceIndexResourceNotFound(t *testing.T) {
+	nonExistentID := "resource2"
 	resource1Id := "resource1"
 	indexTag := "indexTag"
 	resource1 := cloud.Resource{
@@ -84,7 +85,7 @@ func TestGetNewResourceIndexResourceNotFound(t *testing.T) {
 		Tags:       map[string]string{indexTag: "0"},
 		Properties: map[string]string{}}
 	_, err := GetNewResourceIndex(
-		&resource1Id,
+		&nonExistentID,
 		&indexTag,
 		[]*cloud.Resource{&resource1})
 	if err == nil {
@@ -121,8 +122,8 @@ func TestGetNewResourceIndexIndexOk(t *testing.T) {
 	if calculatedIndex != resource1Index {
 		t.Errorf("Index for resource1 = %d; want %d", calculatedIndex, resource1Index)
 	}
-	if err == nil {
-		t.Errorf("Error for resource1 = nil; want != nil")
+	if err != nil {
+		t.Errorf("Error for resource1 = '%v'; want nil", err)
 	}
 	calculatedIndex, err = GetNewResourceIndex(
 		&resource2Id,
@@ -131,8 +132,8 @@ func TestGetNewResourceIndexIndexOk(t *testing.T) {
 	if calculatedIndex != resource2Index {
 		t.Errorf("Index for resource2 = %d; want %d", calculatedIndex, resource2Index)
 	}
-	if err == nil {
-		t.Errorf("Error for resource2 = nil; want != nil")
+	if err != nil {
+		t.Errorf("Error for resource2 = '%v'; want nil", err)
 	}
 }
 


### PR DESCRIPTION
To allow for better integration with tooling built around the index
update subcommand, update the sub-command not to error if the calculated
resource index is unchanged but correct (happens when only one resource
has the index).

Signed-off-by: Jason Rogena <jason@rogena.me>