### PR TITLE
Fix use of multiple tag filters to query for AWS ec2 instances

### DIFF
--- a/infra/query/query.go
+++ b/infra/query/query.go
@@ -69,7 +69,14 @@ func (query *Query) Process() {
 		cli.ExitCommandInterpretationError()
 	}
 
-	allResources, resourcesErr := infra.GetResources(infra.GetFiltersFromCommandFlags(query.providerFlag, query.regionFlag, query.typeFlag, query.tagFlag))
+	allResources, resourcesErr := infra.GetResources(
+		infra.GetFiltersFromCommandFlags(
+			query.providerFlag,
+			query.regionFlag,
+			query.typeFlag,
+			query.tagFlag,
+		),
+	)
 	if resourcesErr != nil {
 		notification.SendMessage(resourcesErr.Error())
 		cli.ExitCommandExecutionError()

--- a/libs/infra/aws/ec2.go
+++ b/libs/infra/aws/ec2.go
@@ -89,7 +89,9 @@ func (e *EC2) getEC2InstancesInRegion(wg *sync.WaitGroup, region string, filter 
 	}))
 
 	ec2Service := ec2.New(session)
-	ec2Instances, ec2InstancesErr := ec2Service.DescribeInstances(e.constructEC2DescribeInstancesInput(filter))
+	ec2Instances, ec2InstancesErr := ec2Service.DescribeInstances(
+		e.constructEC2DescribeInstancesInput(filter),
+	)
 
 	if ec2InstancesErr != nil {
 		finalErr = ec2InstancesErr
@@ -144,8 +146,8 @@ func (e *EC2) constructEC2DescribeInstancesInput(filter *types.InfraFilter) *ec2
 	for curTagKey, curTagValue := range filter.Tags {
 		filterName := "tag:" + curTagKey
 		filters = append(filters, &ec2.Filter{
-			Name:   &filterName,
-			Values: []*string{&curTagValue},
+			Name:   aws.String(filterName),
+			Values: aws.StringSlice([]string{curTagValue}),
 		})
 	}
 


### PR DESCRIPTION
Use AWS SDK's conversion functions to make a pointer of the filter tag
name and value.

fixes #43