### PR TITLE
Add port scanning functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/onaio/sre-tooling
 go 1.12
 
 require (
+	github.com/Ullaakut/nmap/v2 v2.1.0
 	github.com/aws/aws-lambda-go v1.15.0
 	github.com/aws/aws-sdk-go v1.19.44
 	github.com/getsentry/sentry-go v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/getsentry/sentry-go v0.3.0
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/olekukonko/tablewriter v0.0.2
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	pkg.re/essentialkaos/sslscan.v13 v13.0.1+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/Joker/hpp v0.0.0-20180418125244-6893e659854a/go.mod h1:MzD2WMdSxvbHw5fM/OXOFily/lipJWRc9C1px0Mt0ZE=
 github.com/Joker/jade v1.0.0/go.mod h1:efZIdO0py/LtcJRSa/j2WEklMSAw84WV0zZVMxNToB8=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
+github.com/Ullaakut/nmap v1.0.0 h1://XvtkKnrTtEt3E5xzAAtwfvqRoJON/aolr0Larm9eQ=
+github.com/Ullaakut/nmap v2.0.2+incompatible h1:edw45QpSQBQ2B/Hqfg86Bt5rrK79tp/fAcqIHyNSdQs=
+github.com/Ullaakut/nmap/v2 v2.1.0 h1:4omL4HNan3jlhLi7WlKQKist3Q4oq9HEvqr/wqKhJE4=
+github.com/Ullaakut/nmap/v2 v2.1.0/go.mod h1:bWPItdcCK9CkZcAaC7yS9N+t2zijtIjAWBcQtOzV9nM=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/aws/aws-lambda-go v1.15.0 h1:QAhRWvXttl8TtBsODN+NzZETkci2mdN/paJ0+1hX/so=
 github.com/aws/aws-lambda-go v1.15.0/go.mod h1:FEwgPLE6+8wcGBTe5cJN3JWurd1Ztm9zN4jsXsjzKKw=
@@ -81,6 +85,8 @@ github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pingcap/errors v0.11.1/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -95,6 +101,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
@@ -121,6 +128,8 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -140,6 +149,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 pkg.re/essentialkaos/sslscan.v13 v1.0.0 h1:u4HJJsNcTquxCiSFfvSGqPT2RZchGgCXQ8Pc3EgKdvw=
 pkg.re/essentialkaos/sslscan.v13 v13.0.1+incompatible h1:htpUYdGLuHiP1nUj+wKpHHKQEc1p5T1Z/LiEL0jddFc=
 pkg.re/essentialkaos/sslscan.v13 v13.0.1+incompatible/go.mod h1:WWAkk4HRkfROcsMm7PMd0n7xd0RvIvQZL9RN//thERo=

--- a/libs/audit/audit.go
+++ b/libs/audit/audit.go
@@ -118,6 +118,7 @@ func EnabledAudits() map[string]Audit {
 	m := make(map[string]Audit)
 	m["ssl"] = &SSLAudit{}
 	m["ssh"] = &SSHAudit{}
+	m["port"] = &PortScan{}
 
 	return m
 }

--- a/libs/audit/audit.go
+++ b/libs/audit/audit.go
@@ -10,6 +10,9 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// auditFilePath contains file path to audit file
+var auditFilePath string
+
 type Status int
 
 const (
@@ -129,7 +132,9 @@ func Run(inputFile string) ([]*AuditResult, error) {
 	var finalErr error
 	var mutex sync.Mutex
 
-	auditFile, err := ioutil.ReadFile(inputFile)
+	auditFilePath = inputFile
+
+	auditFile, err := ioutil.ReadFile(auditFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/audit/port.go
+++ b/libs/audit/port.go
@@ -1,0 +1,252 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/Ullaakut/nmap/v2"
+	"github.com/mitchellh/mapstructure"
+)
+
+const portAuditName string = "PORT"
+
+// portsEqual tells whether a and b contain the same elements
+func portsEqual(a, b []uint16) bool {
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })
+
+	if len(a) != len(b) {
+		return false
+	}
+
+	for idx, value := range a {
+		if value != b[idx] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// PortTarget holds information about a host to be scanned
+type PortTarget struct {
+	Host          string
+	Group         *PortTargetGroup
+	ScanInfo      *nmap.Run
+	ScanInfoError error
+}
+
+// Scan performs a port scan on a host
+func (t *PortTarget) Scan() {
+	timeout, err := time.ParseDuration(t.Group.Timeout)
+	if err != nil {
+		t.ScanInfoError = err
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	scanner, err := nmap.NewScanner(
+		nmap.WithContext(ctx),
+		nmap.WithTargets(t.Host),
+		nmap.WithSkipHostDiscovery(),
+		// SYNScan and UDPScan require root privileges
+		nmap.WithSYNScan(),
+		nmap.WithUDPScan(),
+	)
+	if err != nil {
+		t.ScanInfoError = err
+		return
+	}
+
+	result, warnings, err := scanner.Run()
+	if warnings != nil {
+		fmt.Printf("[%s] Warnings: \n %v\n", t.Host, warnings)
+	}
+
+	if err != nil {
+		t.ScanInfoError = err
+		return
+	}
+
+	t.ScanInfo = result
+}
+
+// Result constructs results output for a given port scan
+func (t *PortTarget) Result() []*AuditResult {
+	var results []*AuditResult
+	var openPorts []uint16
+	var closedPorts []uint16
+
+	if t.ScanInfoError != nil {
+		res := &AuditResult{
+			Type:          portAuditName,
+			Status:        Error,
+			StatusMessage: fmt.Sprintf("%s: %s", t.Host, t.ScanInfoError.Error()),
+		}
+		results = append(results, res)
+		return results
+	}
+
+	for _, host := range t.ScanInfo.Hosts {
+		for _, port := range host.Ports {
+			switch port.State.State {
+			case string(nmap.Open):
+				openPorts = append(openPorts, port.ID)
+			case string(nmap.Closed):
+				closedPorts = append(closedPorts, port.ID)
+			}
+		}
+	}
+
+	if len(t.Group.AllowList) > 0 {
+		if portsEqual(t.Group.AllowList, openPorts) {
+			statusMsg := fmt.Sprintf(
+				"%s has all allowed ports %v open", t.Host, t.Group.AllowList,
+			)
+			res := &AuditResult{
+				Type:          portAuditName,
+				Status:        Pass,
+				StatusMessage: statusMsg,
+			}
+			results = append(results, res)
+		} else {
+			statusMsg := fmt.Sprintf(
+				"%s has %v open ports but expected %v ports to be open",
+				t.Host, openPorts, t.Group.AllowList,
+			)
+			res := &AuditResult{
+				Type:          portAuditName,
+				Status:        Fail,
+				StatusMessage: statusMsg,
+			}
+			results = append(results, res)
+		}
+	} else if len(t.Group.BlockList) > 0 {
+		if portsEqual(t.Group.BlockList, closedPorts) {
+			statusMsg := fmt.Sprintf(
+				"%s has all blocked ports %v closed", t.Host, t.Group.BlockList,
+			)
+			res := &AuditResult{
+				Type:          portAuditName,
+				Status:        Pass,
+				StatusMessage: statusMsg,
+			}
+			results = append(results, res)
+		} else {
+			statusMsg := fmt.Sprintf(
+				"%s has %v closed ports but expected %v ports to be closed",
+				t.Host, closedPorts, t.Group.BlockList,
+			)
+			res := &AuditResult{
+				Type:          portAuditName,
+				Status:        Fail,
+				StatusMessage: statusMsg,
+			}
+			results = append(results, res)
+		}
+	} else {
+		statusMsg := fmt.Sprintf(
+			"%s does not have any specified allowlist or blocklist", t.Host,
+		)
+		res := &AuditResult{
+			Type:          portAuditName,
+			Status:        Fail,
+			StatusMessage: statusMsg,
+		}
+		results = append(results, res)
+	}
+
+	return results
+}
+
+type PortTargetGroup struct {
+	Timeout   string     `mapstructure:"timeout"`
+	AllowList []uint16   `mapstructure:"allowlist"`
+	BlockList []uint16   `mapstructure:"blocklist"`
+	Discovery *Discovery `mapstructure:"discovery"`
+}
+
+func (tg *PortTargetGroup) Scan() ([]*AuditResult, error) {
+	var portScanResults []*AuditResult
+	var wg sync.WaitGroup
+	var mutex sync.Mutex
+
+	hosts, err := tg.Discovery.GetHosts()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, host := range hosts {
+		target := &PortTarget{
+			Host:  host,
+			Group: tg,
+		}
+
+		handler := func(results []*AuditResult, err error) {
+			mutex.Lock()
+			defer mutex.Unlock()
+
+			portScanResults = append(portScanResults, results...)
+		}
+
+		wg.Add(1)
+
+		go func(target *PortTarget, hander AuditScanHandler) {
+			defer wg.Done()
+
+			target.Scan()
+			results := target.Result()
+			handler(results, nil)
+		}(target, handler)
+	}
+
+	wg.Wait()
+
+	return portScanResults, nil
+}
+
+type PortScan struct {
+	PortTargetGroups []*PortTargetGroup
+}
+
+// Load decodes yaml into struct
+func (ps *PortScan) Load(input interface{}) error {
+	err := mapstructure.Decode(input, &ps.PortTargetGroups)
+	return err
+}
+
+// Scan scans hosts
+func (ps *PortScan) Scan() ([]*AuditResult, error) {
+	var portScanResults []*AuditResult
+	var wg sync.WaitGroup
+	var mutex sync.Mutex
+	var finalErr error
+
+	for _, targetGroup := range ps.PortTargetGroups {
+		handler := func(results []*AuditResult, err error) {
+			mutex.Lock()
+			defer mutex.Unlock()
+
+			portScanResults = append(portScanResults, results...)
+			finalErr = err
+		}
+
+		wg.Add(1)
+
+		go func(tg *PortTargetGroup, handler AuditScanHandler) {
+			defer wg.Done()
+
+			results, err := tg.Scan()
+			handler(results, err)
+		}(targetGroup, handler)
+	}
+
+	wg.Wait()
+
+	return portScanResults, finalErr
+}

--- a/libs/audit/port.go
+++ b/libs/audit/port.go
@@ -1,9 +1,10 @@
 package audit
 
 import (
+	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -83,12 +84,23 @@ func readCommonPorts(commonPortsPath string) ([]string, error) {
 		commonPortsPath,
 	)
 
-	b, err := ioutil.ReadFile(commonPortsFilePath)
+	file, err := os.Open(commonPortsFilePath)
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 
-	ports := strings.Split(strings.TrimSpace(string(b)), ",")
+	ports := []string{}
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		port := strings.TrimSpace(scanner.Text())
+		if port != "" {
+			ports = append(ports, port)
+		}
+	}
+
+	err = scanner.Err()
 
 	return ports, nil
 }

--- a/libs/audit/port_test.go
+++ b/libs/audit/port_test.go
@@ -34,7 +34,7 @@ func TestComparePorts(t *testing.T) {
 	}
 
 	userPorts = []string{"tcp/22", "tcp/80", "tcp/443", "udp/6000-6002"}
-	nmapPorts = []string{"tcp/443", "tcp/80", "tcp/22", "udp/6000", "udp/6001", "udp/6002"}
+	nmapPorts = []string{"tcp/443", "tcp/80", "tcp/22", "udp/6001"}
 	isSimilar = comparePorts(userPorts, nmapPorts)
 	if !isSimilar {
 		t.Errorf(
@@ -44,11 +44,11 @@ func TestComparePorts(t *testing.T) {
 	}
 
 	userPorts = []string{"tcp/22", "tcp/80", "tcp/443", "udp/6000-6002"}
-	nmapPorts = []string{"tcp/443", "tcp/80", "tcp/22", "udp/6000", "udp/6002"}
+	nmapPorts = []string{"tcp/443", "tcp/80", "tcp/22"}
 	isSimilar = comparePorts(userPorts, nmapPorts)
-	if isSimilar {
+	if !isSimilar {
 		t.Errorf(
-			"comparePorts(%v, %v) = %t; want false",
+			"comparePorts(%v, %v) = %t; want true",
 			userPorts, nmapPorts, isSimilar,
 		)
 	}

--- a/libs/audit/port_test.go
+++ b/libs/audit/port_test.go
@@ -2,36 +2,54 @@ package audit
 
 import "testing"
 
-func TestPortsEqual(t *testing.T) {
-	equalPortsTest1 := portsEqual([]uint16{22, 80, 443}, []uint16{80, 443, 22})
-	if !equalPortsTest1 {
+func TestComparePorts(t *testing.T) {
+	userPorts := []string{"tcp/22", "tcp/80", "tcp/443"}
+	nmapPorts := []string{"tcp/443", "tcp/80", "tcp/22"}
+	isSimilar := comparePorts(userPorts, nmapPorts)
+	if !isSimilar {
 		t.Errorf(
-			"portsEqual(([]uint16{22, 80, 443}, []uint16{80, 443, 22}) = %t; want true",
-			equalPortsTest1,
+			"comparePorts(%v, %v) = %t; want true",
+			userPorts, nmapPorts, isSimilar,
 		)
 	}
 
-	equalPortsTest2 := portsEqual([]uint16{22}, []uint16{80})
-	if equalPortsTest2 {
+	userPorts = []string{"tcp/22", "tcp/80", "tcp/443", "udp/123"}
+	nmapPorts = []string{"tcp/443", "tcp/80", "tcp/22"}
+	isSimilar = comparePorts(userPorts, nmapPorts)
+	if isSimilar {
 		t.Errorf(
-			"portsEqual([]uint16{22}, []uint16{80}) = %t; want false",
-			equalPortsTest2,
+			"comparePorts(%v, %v) = %t; want false",
+			userPorts, nmapPorts, isSimilar,
 		)
 	}
 
-	equalPortsTest3 := portsEqual([]uint16{22}, []uint16{80, 22})
-	if equalPortsTest3 {
+	userPorts = []string{"tcp/22", "tcp/80", "tcp/443"}
+	nmapPorts = []string{"tcp/443", "tcp/80", "tcp/22", "udp/123"}
+	isSimilar = comparePorts(userPorts, nmapPorts)
+	if isSimilar {
 		t.Errorf(
-			"portsEqual([]uint16{22}, []uint16{80, 22}) = %t; want false",
-			equalPortsTest3,
+			"comparePorts(%v, %v) = %t; want false",
+			userPorts, nmapPorts, isSimilar,
 		)
 	}
 
-	equalPortsTest4 := portsEqual([]uint16{}, []uint16{})
-	if !equalPortsTest4 {
+	userPorts = []string{"tcp/22", "tcp/80", "tcp/443", "udp/6000-6002"}
+	nmapPorts = []string{"tcp/443", "tcp/80", "tcp/22", "udp/6000", "udp/6001", "udp/6002"}
+	isSimilar = comparePorts(userPorts, nmapPorts)
+	if !isSimilar {
 		t.Errorf(
-			"portsEqual(([]uint16{}, []uint16{}) = %t; want true",
-			equalPortsTest4,
+			"comparePorts(%v, %v) = %t; want true",
+			userPorts, nmapPorts, isSimilar,
+		)
+	}
+
+	userPorts = []string{"tcp/22", "tcp/80", "tcp/443", "udp/6000-6002"}
+	nmapPorts = []string{"tcp/443", "tcp/80", "tcp/22", "udp/6000", "udp/6002"}
+	isSimilar = comparePorts(userPorts, nmapPorts)
+	if isSimilar {
+		t.Errorf(
+			"comparePorts(%v, %v) = %t; want false",
+			userPorts, nmapPorts, isSimilar,
 		)
 	}
 }

--- a/libs/audit/port_test.go
+++ b/libs/audit/port_test.go
@@ -1,0 +1,37 @@
+package audit
+
+import "testing"
+
+func TestPortsEqual(t *testing.T) {
+	equalPortsTest1 := portsEqual([]uint16{22, 80, 443}, []uint16{80, 443, 22})
+	if !equalPortsTest1 {
+		t.Errorf(
+			"portsEqual(([]uint16{22, 80, 443}, []uint16{80, 443, 22}) = %t; want true",
+			equalPortsTest1,
+		)
+	}
+
+	equalPortsTest2 := portsEqual([]uint16{22}, []uint16{80})
+	if equalPortsTest2 {
+		t.Errorf(
+			"portsEqual([]uint16{22}, []uint16{80}) = %t; want false",
+			equalPortsTest2,
+		)
+	}
+
+	equalPortsTest3 := portsEqual([]uint16{22}, []uint16{80, 22})
+	if equalPortsTest3 {
+		t.Errorf(
+			"portsEqual([]uint16{22}, []uint16{80, 22}) = %t; want false",
+			equalPortsTest3,
+		)
+	}
+
+	equalPortsTest4 := portsEqual([]uint16{}, []uint16{})
+	if !equalPortsTest4 {
+		t.Errorf(
+			"portsEqual(([]uint16{}, []uint16{}) = %t; want true",
+			equalPortsTest4,
+		)
+	}
+}


### PR DESCRIPTION
**NB:**

- You need to have `nmap` installed in the environment you are running this tool
- The scanning feature uses `SYN` and `UDP` scans which require root privileges
- Input format is as shown below:

  ```yaml
  port:
    - discovery:
        type: AWS
        resource_types:
          - EC2
        regions:
          - eu-central-1
        tags:
          App: U-Report
      allowlist:
        - 22
      timeout: 5m
    - discovery:
        type: host
        targets:
          - 197.210.136.181
          - 197.210.136.180
          - 197.210.136.178
          - 197.210.136.182
      allowlist:
        - 80
        - 443
      blocklist:
        - 22
      timeout: 5m
    - discovery:
        type: host
        targets:
          - 34.252.205.12
      allowlist:
        - 22
      timeout: 5m
  ```